### PR TITLE
implemented remove dapp core

### DIFF
--- a/command/install.go
+++ b/command/install.go
@@ -8,11 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/privatix/dapp-installer/dapp"
 	"github.com/privatix/dapp-installer/data"
 	"github.com/privatix/dapp-installer/dbengine"
 	"github.com/privatix/dapp-installer/util"
-	"github.com/privatix/dapp-installer/windows"
 	dapputil "github.com/privatix/dappctrl/util"
 	"github.com/privatix/dappctrl/util/log"
 )
@@ -91,23 +89,6 @@ func finalize(cmd *installCmd, conf *config, logger log.Logger) error {
 		logger.Info("backup version was removed")
 	}
 	return nil
-}
-
-func existingDapp(role string, logger log.Logger) (*dapp.Dapp, bool) {
-	maps, ok := util.ExistingDapp(role, logger)
-
-	if !ok {
-		return nil, false
-	}
-
-	d := &dapp.Dapp{
-		Version:     maps["Version"],
-		InstallPath: maps["BaseDirectory"],
-		Service: &windows.Service{
-			GUID: maps["ServiceID"],
-		},
-	}
-	return d, true
 }
 
 func checkDapp(cmd *installCmd, conf *config, logger log.Logger) error {

--- a/command/remove.go
+++ b/command/remove.go
@@ -1,10 +1,13 @@
 package command
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 
+	"github.com/privatix/dapp-installer/data"
+	"github.com/privatix/dapp-installer/util"
 	"github.com/privatix/dappctrl/util/log"
 )
 
@@ -47,7 +50,47 @@ func (cmd *removeCmd) execute(conf *config, log log.Logger) error {
 	logger.Info("start process")
 	defer logger.Info("finish process")
 
-	fmt.Println("I will be running uninstallation process")
+	existDapp, ok := existingDapp(conf.Dapp.UserRole, logger)
+	if !ok {
+		msg := fmt.Sprintf("dapp (%s) is not found", conf.Dapp.UserRole)
+		fmt.Println(msg)
+		logger.Warn(msg)
+		return nil
+	}
+
+	conf.Dapp = existDapp
+	return remove(conf, logger)
+}
+
+func remove(conf *config, logger log.Logger) error {
+	dapp := conf.Dapp
+
+	db, err := dbParamsFromConfig(dapp.InstallPath + dapp.Configuration)
+	if err != nil {
+		logger.Warn(fmt.Sprintf(
+			"ocurred error when read config %v", err))
+		return err
+	}
+
+	if data.DBExists(db, logger) {
+		dapp.Service.Stop()
+		dapp.Service.Remove()
+
+		if err := data.DropDatabase(db); err != nil {
+			logger.Warn(fmt.Sprintf(
+				"ocurred error when drop database %v", err))
+			return err
+		}
+	}
+
+	if err := dapp.Remove(); err != nil {
+		logger.Warn(fmt.Sprintf(
+			"ocurred error when remove dapp %v", err))
+		return err
+	}
+
+	util.RemoveRegistryKey(conf.Registry, dapp.UserRole)
+
 	return nil
 }
 
@@ -59,6 +102,35 @@ func (cmd *removeCmd) rollback(conf *config, logger log.Logger) {
 
 func (cmd *removeCmd) addRollbackFuncs(f func(c *config, l log.Logger)) {
 	cmd.rollbackFuncs = append(cmd.rollbackFuncs, f)
+}
+
+func dbParamsFromConfig(configFile string) (*data.DB, error) {
+	read, err := os.Open(configFile)
+	if err != nil {
+		return nil, err
+	}
+	defer read.Close()
+
+	jsonMap := make(map[string]interface{})
+
+	json.NewDecoder(read).Decode(&jsonMap)
+
+	db, ok := jsonMap["DB"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("DB params not found")
+	}
+	conn, ok := db["Conn"].(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Conn params not found")
+	}
+
+	res := &data.DB{
+		DBName:   conn["dbname"].(string),
+		User:     conn["user"].(string),
+		Password: conn["password"].(string),
+		Port:     conn["port"].(string),
+	}
+	return res, nil
 }
 
 func removeHelp() {

--- a/dapp-installer.config.json
+++ b/dapp-installer.config.json
@@ -37,11 +37,6 @@
                 "Value":"The Privatix Dapp, packaged by Privatix"
             },
             {
-                "Name" : "EstimatedSize",
-                "Type":"dword",
-                "Value":"10000"
-            },
-            {
                 "Name" : "HelpLink",
                 "Type":"string",
                 "Value":"https://privatix.io"
@@ -62,11 +57,6 @@
                 "Value":"Privatix (c)"
             },
             {
-                "Name" : "UninstallString",
-                "Type":"string",
-                "Value":"dapp-installer.exe remove"
-            },
-            {
                 "Name" : "UrlInfoAbout",
                 "Type":"string",
                 "Value":"https://privatix.io"
@@ -85,6 +75,7 @@
     },
     "Dapp": {
         "UserRole" : "agent",
+        "Shortcuts" : true,
         "DownloadCtrl" : "http://localhost/dapp/dappctrl.exe",
         "DownloadConfig" : "http://localhost/dapp/dappctrl.config.json",
         "DownloadGui" : "http://localhost/dapp/dappgui.exe",

--- a/dapp/dapp.go
+++ b/dapp/dapp.go
@@ -9,11 +9,15 @@ import (
 type Dapp struct {
 	DownloadCtrl   string
 	Controller     string
+	Gui            string
 	DownloadConfig string
+	Configuration  string
 	DownloadGui    string
+	Installer      string
 	InstallPath    string
 	BackupPath     string
 	Service        *windows.Service
+	Shortcuts      bool
 	UserRole       string
 	Version        string
 }

--- a/dapp/dapp_windows.go
+++ b/dapp/dapp_windows.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/privatix/dapp-installer/data"
@@ -59,15 +58,23 @@ func downloadAndConfigurateFiles(dapp *Dapp, db *data.DB) error {
 	if err != nil {
 		return err
 	}
-	configFile := dapp.InstallPath + path.Base(dapp.DownloadConfig)
+
+	_, dapp.Installer = filepath.Split(os.Args[0])
+	err = util.CopyFile(os.Args[0], dapp.InstallPath+dapp.Installer)
+	if err != nil {
+		return err
+	}
+
+	_, dapp.Configuration = filepath.Split(dapp.DownloadConfig)
+	configFile := dapp.InstallPath + dapp.Configuration
 	err = util.DownloadFile(configFile, dapp.DownloadConfig)
 	if err != nil {
 		return err
 	}
-	return modifyDappConfig(configFile, db)
+	return modifyDappConfig(configFile, db, dapp.UserRole)
 }
 
-func modifyDappConfig(configFile string, dbConf *data.DB) error {
+func modifyDappConfig(configFile string, dbConf *data.DB, role string) error {
 	read, err := os.Open(configFile)
 	if err != nil {
 		return err
@@ -85,6 +92,10 @@ func modifyDappConfig(configFile string, dbConf *data.DB) error {
 			conn["port"] = dbConf.Port
 			conn["dbname"] = dbConf.DBName
 		}
+	}
+
+	if _, ok := jsonMap["Role"]; ok {
+		jsonMap["Role"] = role
 	}
 
 	write, err := os.Create(configFile)

--- a/util/misc.go
+++ b/util/misc.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -120,4 +121,39 @@ func TemporaryDownload(installPath, downloadPath string) (string, error) {
 	}
 	fileName := installPath + "temporary." + path.Base(downloadPath)
 	return fileName, DownloadFile(fileName, downloadPath)
+}
+
+// CopyFile copies file.
+func CopyFile(src, dst string) error {
+	var err error
+	var srcfd *os.File
+	var dstfd *os.File
+	var srcinfo os.FileInfo
+	if srcfd, err = os.Open(src); err != nil {
+		return err
+	}
+	defer srcfd.Close()
+	if dstfd, err = os.Create(dst); err != nil {
+		return err
+	}
+	defer dstfd.Close()
+	if _, err = io.Copy(dstfd, srcfd); err != nil {
+		return err
+	}
+	if srcinfo, err = os.Stat(src); err != nil {
+		return err
+	}
+	return os.Chmod(dst, srcinfo.Mode())
+}
+
+// DirSize returns total dir size.
+func DirSize(path string) (int64, error) {
+	var size int64
+	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if !info.IsDir() {
+			size += info.Size()
+		}
+		return err
+	})
+	return size, err
 }

--- a/util/win_registry.go
+++ b/util/win_registry.go
@@ -136,13 +136,13 @@ func getInstalledDappVersion(role string) (map[string]string, error) {
 			v, _, _ := k.GetStringValue("Version")
 			s, _, _ := k.GetStringValue("ServiceID")
 			p, _, _ := k.GetStringValue("BaseDirectory")
-			d, _, _ := k.GetStringValue("Database")
+			c, _, _ := k.GetStringValue("Configuration")
 
 			maps := make(map[string]string)
 			maps["Version"] = v
 			maps["ServiceID"] = s
 			maps["BaseDirectory"] = p
-			maps["Database"] = d
+			maps["Configuration"] = c
 			return maps, nil
 		}
 	}


### PR DESCRIPTION
Command for removing DApp was implemented.

This commit includes the following changes:

1. Function to calculate dapp core size.
2. `Role` parameters value was set into `dappctrl` config file.
3. `dapp-installer` copies themselves into install directory.
4. Implementations for `remove` command

Resolves BV-737.