### PR TITLE
compare dapp's version and database removing were fixed

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -38,11 +38,16 @@ type command interface {
 }
 
 type config struct {
+	// InstallPath contains a path to installation.
 	InstallPath string
-	TempPath    string
-	DBEngine    *dbengine.DBEngine
-	Registry    *util.Registry
-	Dapp        *dapp.Dapp
+	// TempPath contains a temporary path to downloads.
+	TempPath string
+	// DBEngine contains a db engine parameters.
+	DBEngine *dbengine.DBEngine
+	// Registry contains a winregistry parameters.
+	Registry *util.Registry
+	// Dapp contains a dapp installation parameters.
+	Dapp *dapp.Dapp
 }
 
 func newConfig() *config {

--- a/command/command.go
+++ b/command/command.go
@@ -106,7 +106,7 @@ func createRegistryKey(conf *config) error {
 	db := conf.DBEngine.DB
 	shortcuts := strconv.FormatBool(d.Shortcuts)
 	conf.Registry.Install = append(conf.Registry.Install,
-		util.Key{Name: "Shotrcuts", Type: "string", Value: shortcuts},
+		util.Key{Name: "Shortcuts", Type: "string", Value: shortcuts},
 		util.Key{Name: "BaseDirectory", Type: "string", Value: d.InstallPath},
 		util.Key{Name: "Version", Type: "string", Value: d.Version},
 		util.Key{Name: "ServiceID", Type: "string", Value: d.Service.GUID},
@@ -194,11 +194,14 @@ func existingDapp(role string, logger log.Logger) (*dapp.Dapp, bool) {
 		return nil, false
 	}
 
+	shortcut, _ := strconv.ParseBool(maps["Shortcuts"])
 	d := &dapp.Dapp{
 		UserRole:      role,
 		Version:       maps["Version"],
 		InstallPath:   maps["BaseDirectory"],
 		Configuration: maps["Configuration"],
+		Gui:           maps["Gui"],
+		Shortcuts:     shortcut,
 		Service: &windows.Service{
 			GUID: maps["ServiceID"],
 		},

--- a/command/command.go
+++ b/command/command.go
@@ -39,6 +39,7 @@ type command interface {
 
 type config struct {
 	InstallPath string
+	TempPath    string
 	DBEngine    *dbengine.DBEngine
 	Registry    *util.Registry
 	Dapp        *dapp.Dapp

--- a/command/install.go
+++ b/command/install.go
@@ -72,11 +72,15 @@ func (cmd *installCmd) execute(conf *config, log log.Logger) error {
 		return err
 	}
 
-	if ok, err := checkDapp(cmd, conf, logger); !ok || err != nil {
+	ok, err := checkDapp(cmd, conf, logger)
+	if err != nil {
 		return err
 	}
 
-	return finalize(cmd, conf, logger)
+	if ok {
+		return finalize(cmd, conf, logger)
+	}
+	return nil
 }
 
 func finalize(cmd *installCmd, conf *config, logger log.Logger) error {

--- a/command/install.go
+++ b/command/install.go
@@ -108,7 +108,8 @@ func checkDapp(cmd *installCmd, conf *config, logger log.Logger) error {
 		newDapp.InstallPath += "\\"
 	}
 
-	if ok && existDapp.Version >= newDapp.Version {
+	version := util.ParseVersion(newDapp.Version)
+	if ok && util.ParseVersion(existDapp.Version) >= version {
 		util.RemoveFile(path)
 		fmt.Printf("you have not to update. your dapp version: %v\n",
 			existDapp.Version)

--- a/command/remove.go
+++ b/command/remove.go
@@ -73,8 +73,7 @@ func remove(conf *config, logger log.Logger) error {
 	}
 
 	if data.DBExists(db, logger) {
-		dapp.Service.Stop()
-		dapp.Service.Remove()
+		dapp.Service.Uninstall()
 
 		if err := data.DropDatabase(db); err != nil {
 			logger.Warn(fmt.Sprintf(

--- a/dapp-installer.config.json
+++ b/dapp-installer.config.json
@@ -1,7 +1,7 @@
 {
     "InstallPath" : "C:\\Program Files\\Privatix\\Dapp\\",
     "DBEngine": {
-        "Download" : "https://get.enterprisedb.com/postgresql/postgresql-10.5-1-windows-x64.exe",
+        "Download" : "http://localhost/dapp/postgresql-10.5-1-windows-x64.exe",
         "ServiceName": "postgresdapp",
         "DataDir": "C:\\Program Files\\PostgreSQL\\10\\data",
         "InstallDir": "C:\\Program Files\\PostgreSQL\\10",

--- a/dapp/dapp.go
+++ b/dapp/dapp.go
@@ -1,6 +1,8 @@
 package dapp
 
 import (
+	"path"
+
 	"github.com/privatix/dapp-installer/util"
 	"github.com/privatix/dapp-installer/windows"
 )
@@ -15,6 +17,7 @@ type Dapp struct {
 	DownloadGui    string
 	Installer      string
 	InstallPath    string
+	TempPath       string
 	BackupPath     string
 	Service        *windows.Service
 	Shortcuts      bool
@@ -28,11 +31,11 @@ func NewConfig() *Dapp {
 }
 
 // DownloadDappCtrl returns temporary downloaded path.
-func (d *Dapp) DownloadDappCtrl(path string) string {
-	tempDappCtrl, err := util.TemporaryDownload(path, d.DownloadCtrl)
-	if err != nil {
+func (d *Dapp) DownloadDappCtrl() string {
+	filePath := d.TempPath + path.Base(d.DownloadCtrl)
+	if err := util.DownloadFile(filePath, d.DownloadCtrl); err != nil {
 		return ""
 	}
 
-	return tempDappCtrl
+	return filePath
 }

--- a/dapp/dapp_windows.go
+++ b/dapp/dapp_windows.go
@@ -49,6 +49,12 @@ func (d *Dapp) Install(db *data.DB, logger log.Logger, ok bool) error {
 func (d *Dapp) Remove() error {
 	d.Service.Stop()
 	d.Service.Remove()
+	if d.Shortcuts {
+		extension := filepath.Ext(d.Gui)
+		linkName := d.Gui[0 : len(d.Gui)-len(extension)]
+		link := util.DesktopPath() + "\\" + linkName + ".lnk"
+		os.Remove(link)
+	}
 	return os.RemoveAll(d.InstallPath)
 }
 

--- a/dapp/dapp_windows.go
+++ b/dapp/dapp_windows.go
@@ -54,8 +54,8 @@ func (d *Dapp) Remove() error {
 
 func downloadAndConfigurateFiles(dapp *Dapp, db *data.DB) error {
 	_, dapp.Controller = filepath.Split(dapp.DownloadCtrl)
-	err := util.DownloadFile(dapp.InstallPath+dapp.Controller,
-		dapp.DownloadCtrl)
+	err := util.CopyFile(dapp.TempPath+dapp.Controller,
+		dapp.InstallPath+dapp.Controller)
 	if err != nil {
 		return err
 	}

--- a/dapp/dapp_windows.go
+++ b/dapp/dapp_windows.go
@@ -39,16 +39,18 @@ func (d *Dapp) Install(db *data.DB, logger log.Logger, ok bool) error {
 	}
 	logger.Info("start service")
 	if err := d.Service.Start(); err != nil {
-		logger.Warn("ocurred error when start service " + d.Service.ID)
-		return err
+		// retry attempt to start service
+		if err := d.Service.Start(); err != nil {
+			logger.Warn("ocurred error when start service " + d.Service.ID)
+			return err
+		}
 	}
 	return nil
 }
 
 // Remove removes installed dapp core.
 func (d *Dapp) Remove() error {
-	d.Service.Stop()
-	d.Service.Remove()
+	d.Service.Uninstall()
 	if d.Shortcuts {
 		extension := filepath.Ext(d.Gui)
 		linkName := d.Gui[0 : len(d.Gui)-len(extension)]
@@ -59,7 +61,6 @@ func (d *Dapp) Remove() error {
 }
 
 func downloadAndConfigurateFiles(dapp *Dapp, db *data.DB) error {
-	_, dapp.Controller = filepath.Split(dapp.DownloadCtrl)
 	err := util.CopyFile(dapp.TempPath+dapp.Controller,
 		dapp.InstallPath+dapp.Controller)
 	if err != nil {

--- a/dbengine/dbengine_unix.go
+++ b/dbengine/dbengine_unix.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Install installs a DB engine.
-func (engine *DBEngine) Install(logger log.Logger) error {
+func (engine *DBEngine) Install(path string, logger log.Logger) error {
 	logger.Warn(fmt.Sprintf("your OS %s is not supported now", runtime.GOOS))
 	return errors.New("is not supported for this feature")
 }

--- a/dbengine/dbengine_windows.go
+++ b/dbengine/dbengine_windows.go
@@ -14,8 +14,8 @@ import (
 )
 
 // Install installs a DB engine.
-func (engine *DBEngine) Install(logger log.Logger) error {
-	fileName := path.Base(engine.Download)
+func (engine *DBEngine) Install(installPath string, logger log.Logger) error {
+	fileName := installPath + path.Base(engine.Download)
 	if err := util.DownloadFile(fileName, engine.Download); err != nil {
 		logger.Warn("ocurred error when downloded file: " + engine.Download)
 		return err

--- a/util/misc.go
+++ b/util/misc.go
@@ -103,10 +103,15 @@ func DappCtrlVersion(filename string) string {
 		return ""
 	}
 
-	if strings.Contains(output.String(), "undefined (undefined)") {
+	version := output.String()
+	if i := strings.Index(version, " "); i > 0 {
+		version = version[:i]
+	}
+
+	if strings.Contains(version, "undefined") {
 		return "0.0.0"
 	}
-	return output.String()
+	return version
 }
 
 // RemoveFile removes file.
@@ -156,4 +161,25 @@ func DirSize(path string) (int64, error) {
 		return err
 	})
 	return size, err
+}
+
+// ParseVersion returns version number in int64 format.
+func ParseVersion(s string) int64 {
+	strList := strings.Split(s, ".")
+	length := len(strList)
+	for i := 0; i < (4 - length); i++ {
+		strList = append(strList, "0")
+	}
+
+	format := fmt.Sprintf("%%s%%0%ds", 4)
+	v := ""
+	for _, value := range strList {
+		v = fmt.Sprintf(format, v, value)
+	}
+
+	result, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return result
 }

--- a/util/misc.go
+++ b/util/misc.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"bytes"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"math"
@@ -23,8 +24,10 @@ const (
 
 // WriteCounter type is used for download process.
 type WriteCounter struct {
-	Processed uint64
-	Total     uint64
+	Label        string
+	Processed    uint64
+	Total        uint64
+	OutputLenght int
 }
 
 func (wc *WriteCounter) Write(p []byte) (int, error) {
@@ -34,10 +37,12 @@ func (wc *WriteCounter) Write(p []byte) (int, error) {
 	return n, nil
 }
 
-func (wc WriteCounter) printProgress() {
-	fmt.Printf("\r%s", strings.Repeat(" ", 35))
-	fmt.Printf("\rDownloading... %s from %s",
-		humanateBytes(wc.Processed), humanateBytes(wc.Total))
+func (wc *WriteCounter) printProgress() {
+	fmt.Printf("\r%s", strings.Repeat(" ", wc.OutputLenght+1))
+	output := fmt.Sprintf("\rDownloading %s ... %s from %s",
+		wc.Label, humanateBytes(wc.Processed), humanateBytes(wc.Total))
+	wc.OutputLenght = len(output)
+	fmt.Printf(output)
 }
 
 // DownloadFile downloads the file.
@@ -59,7 +64,7 @@ func DownloadFile(filePath, url string) error {
 		return err
 	}
 
-	counter := &WriteCounter{Total: uint64(length)}
+	counter := &WriteCounter{Label: path.Base(url), Total: uint64(length)}
 
 	_, err = io.Copy(out, io.TeeReader(resp.Body, counter))
 	if err != nil {
@@ -119,13 +124,20 @@ func RemoveFile(filename string) error {
 	return os.Remove(filename)
 }
 
-// TemporaryDownload downloads file to the temp installation directory.
-func TemporaryDownload(installPath, downloadPath string) (string, error) {
-	if _, err := os.Stat(installPath); os.IsNotExist(err) {
-		os.MkdirAll(installPath, 0644)
+// TempPath creates temporary directory.
+func TempPath(volume string) string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf(`%s\temporary\`, volume)
 	}
-	fileName := installPath + "temporary." + path.Base(downloadPath)
-	return fileName, DownloadFile(fileName, downloadPath)
+
+	path := fmt.Sprintf(`%s\%x\`, volume, b)
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		os.MkdirAll(path, 0644)
+	}
+
+	return path
 }
 
 // CopyFile copies file.

--- a/util/misc_test.go
+++ b/util/misc_test.go
@@ -1,0 +1,30 @@
+package util
+
+import "testing"
+
+type testpair struct {
+	version string
+	value   int64
+}
+
+var tests = []testpair{
+	{"0.0.0", 0},
+	{"0.0.1", 10000},
+	{"0.0.0.5", 5},
+	{"0.11.0", 1100000000},
+	{"1.0.0.57", 1000000000057},
+	{"1.0", 1000000000000},
+}
+
+func TestParseVersion(t *testing.T) {
+	for _, pair := range tests {
+		v := ParseVersion(pair.version)
+		if v != pair.value {
+			t.Error(
+				"For", pair.version,
+				"expected", pair.value,
+				"got", v,
+			)
+		}
+	}
+}

--- a/util/win_registry.go
+++ b/util/win_registry.go
@@ -137,12 +137,16 @@ func getInstalledDappVersion(role string) (map[string]string, error) {
 			s, _, _ := k.GetStringValue("ServiceID")
 			p, _, _ := k.GetStringValue("BaseDirectory")
 			c, _, _ := k.GetStringValue("Configuration")
+			g, _, _ := k.GetStringValue("Gui")
+			sh, _, _ := k.GetStringValue("Shortcuts")
 
 			maps := make(map[string]string)
 			maps["Version"] = v
 			maps["ServiceID"] = s
 			maps["BaseDirectory"] = p
 			maps["Configuration"] = c
+			maps["Gui"] = g
+			maps["Shortcuts"] = sh
 			return maps, nil
 		}
 	}

--- a/windows/service.go
+++ b/windows/service.go
@@ -29,6 +29,12 @@ func (s *Service) Install() error {
 	return util.ExecuteCommand(s.GUID, []string{"install"})
 }
 
+// Uninstall uninstalls windows service.
+func (s *Service) Uninstall() {
+	s.Stop()
+	s.Remove()
+}
+
 // Start starts windows service.
 func (s *Service) Start() error {
 	return util.ExecuteCommand(s.GUID, []string{"start"})


### PR DESCRIPTION
This commits contains the following changes:
1.  `ParseVersion` func for versions compare
2.  fixed `error has been occurred during removing the DB`
3.  display filename at downloading
4.  temporary folder used to download
5.  removing shortcut when remove dapp
6. fixed `system service has not started automatically`

Resolves part of BV-867