### PR TITLE
migrating to dep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ statik.go
 .vscode/*
 
 \.DS_Store
+
+# Go dependency management tool files
+/vendor
+Gopkg.lock
+

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,0 +1,10 @@
+ignored = ["github.com/satori/go.uuid"]
+
+[[constraint]]
+  name = "github.com/privatix/dapp-openvpn"
+  source = "https://github.com/privatix/dapp-openvpn.git"
+  
+[[constraint]]
+  name = "github.com/privatix/dappctrl"
+  source = "https://github.com/privatix/dappctrl.git"
+  

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ go get -u github.com/josephspurrier/goversioninfo/cmd/goversioninfo
 Build `dapp-installer` package:
 
 ```bash
+curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+dep ensure
 go generate ./...
 
 GIT_COMMIT=$(git rev-list -1 HEAD)


### PR DESCRIPTION
Resolves the follow error on build:
`# github.com/privatix/dapp-installer/command
command\command.go:45:20: cannot use logger (type "github.com/privatix/dappctrl/util/log".Logger) as type "github.com/privatix/dapp-openvpn/vendor/github.com/privatix/dappctrl/util/log".Logger in argument to flow.Run:
        "github.com/privatix/dappctrl/util/log".Logger does not implement "github.com/privatix/dapp-openvpn/vendor/github.com/privatix/dappctrl/util/log".Logger (wrong type for Add method)
                have Add(...interface {}) "github.com/privatix/dappctrl/util/log".Logger
                want Add(...interface {}) "github.com/privatix/dapp-openvpn/vendor/github.com/privatix/dappctrl/util/log".Logger`