### PR TITLE
fixed: tor service creation fails without settings folder

### DIFF
--- a/command/funcs.go
+++ b/command/funcs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	dapputil "github.com/privatix/dappctrl/util"
@@ -81,7 +80,7 @@ func validatePath(d *dapp.Dapp) error {
 	if err != nil {
 		return err
 	}
-	d.Path = filepath.ToSlash(strings.ToLower(path))
+	d.Path = filepath.ToSlash(path)
 	d.Tor.RootPath = d.Path
 	return nil
 }

--- a/statik/templates/torrc.tpl
+++ b/statik/templates/torrc.tpl
@@ -5,9 +5,4 @@ HiddenServicePort {{.VirtPort}} 127.0.0.1:{{.TargetPort}}
 
 DataDirectory "{{.RootPath}}/tor/data"
 
-GeoIPFile /settings/geoip
-GeoIPv6File /settings/geoip6
-
-#SafeLogging 0
 Log notice file {{.RootPath}}/log/tor.log
-#Log info file {{.RootPath}}/log/torinfo.log

--- a/tor/tor.go
+++ b/tor/tor.go
@@ -89,7 +89,17 @@ func (t *Tor) generateKey() error {
 }
 
 func (t *Tor) createSettings() error {
-	file, err := os.Create(filepath.Join(t.RootPath, "tor/settings/torrc"))
+	path := filepath.Join(t.RootPath, "tor/settings")
+	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.MkdirAll(path, 0644); err != nil {
+			return err
+		}
+	}
+
+	file, err := os.Create(filepath.Join(path, "torrc"))
 	if err != nil {
 		return err
 	}

--- a/util/misc.go
+++ b/util/misc.go
@@ -228,7 +228,7 @@ func CopyDir(src string, dst string) error {
 // Hash returns string hash.
 func Hash(s string) string {
 	h := sha1.New()
-	h.Write([]byte(s))
+	h.Write([]byte(strings.ToLower(s)))
 	return hex.EncodeToString(h.Sum(nil))
 }
 


### PR DESCRIPTION
Resolves `Case sensitive for paths`, BV-1075.