### PR TITLE
adds context to logs output

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -22,21 +23,27 @@ func Execute(logger log.Logger, version func(), args []string) {
 	switch strings.ToLower(args[0]) {
 	case "install":
 		logger.Info("install process")
+		logger = logger.Add("action", "install")
 		flow = installFlow()
 	case "install-products":
 		logger.Info("install products process")
+		logger = logger.Add("action", "install products")
 		flow = installProductsFlow()
 	case "update":
 		logger.Info("update process")
+		logger = logger.Add("action", "update")
 		flow = updateFlow()
 	case "remove":
 		logger.Info("remove process")
+		logger = logger.Add("action", "remove")
 		flow = removeFlow()
 	case "remove-products":
 		logger.Info("remove products process")
+		logger = logger.Add("action", "remove products")
 		flow = removeProductsFlow()
 	case "status":
 		logger.Info("status process")
+		logger = logger.Add("action", "status")
 		flow = statusFlow()
 	case "help":
 		fmt.Println(rootHelp)
@@ -49,6 +56,8 @@ func Execute(logger log.Logger, version func(), args []string) {
 	d := dapp.NewDapp()
 
 	if err := flow.Run(d, logger); err != nil {
+		object, _ := json.Marshal(d)
+		logger = logger.Add("object", string(object))
 		logger.Error(fmt.Sprintf("%v", err))
 		os.Exit(2)
 	}

--- a/dapp/dapp_unix.go
+++ b/dapp/dapp_unix.go
@@ -67,8 +67,7 @@ func (d *Dapp) Configurate() error {
 		}
 	}
 
-	_, installer := filepath.Split(os.Args[0])
-	return util.CopyFile(os.Args[0], filepath.Join(d.Path, installer))
+	return nil
 }
 
 func copyServiceWrapper(d, s *Dapp) {

--- a/dapp/dapp_windows.go
+++ b/dapp/dapp_windows.go
@@ -4,7 +4,6 @@ package dapp
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/privatix/dapp-installer/dbengine"
@@ -47,9 +46,6 @@ func (d *Dapp) Configurate() error {
 	if d.Gui.Symlink {
 		d.createSymlink()
 	}
-
-	_, installer := filepath.Split(os.Args[0])
-	util.CopyFile(os.Args[0], filepath.Join(d.Path, installer))
 
 	ctrl := d.Controller
 	ctrlPath := filepath.Join(d.Path, filepath.Dir(ctrl.EntryPoint))


### PR DESCRIPTION
1. Adds context to logs output.
2. Removes copying itself to the installation dir.

Resolves BV-1192.