### PR TITLE
change 5555 port to 3452

### DIFF
--- a/tor/tor.go
+++ b/tor/tor.go
@@ -43,7 +43,7 @@ func NewTor() *Tor {
 		HiddenServiceDir: "tor/hidden_service",
 		SocksPort:        9999,
 		VirtPort:         80,
-		TargetPort:       5555,
+		TargetPort:       3452,
 		Config:           "torrc",
 		IsLinux:          runtime.GOOS == "linux",
 	}


### PR DESCRIPTION
Android studio is often use 5555 port for Android Debug Bridge.
So, we should change it by default to 3452